### PR TITLE
 Add configuration for appending custom app name to user agent.

### DIFF
--- a/lib/smartsheet/api/header_builder.rb
+++ b/lib/smartsheet/api/header_builder.rb
@@ -7,10 +7,11 @@ module Smartsheet
     # Constructs headers for accessing the Smartsheet API
     class HeaderBuilder
       include Smartsheet::Constants
-      def initialize(token, endpoint_spec, request_spec, assume_user: nil)
+      def initialize(token, endpoint_spec, request_spec, app_user_agent: nil, assume_user: nil)
         @token = token
         @endpoint_spec = endpoint_spec
         @request_spec = request_spec
+        @app_user_agent = app_user_agent
         @assume_user = assume_user
       end
 
@@ -32,11 +33,16 @@ module Smartsheet
       def base_headers
         base = {
             Accept: JSON_TYPE,
-            'User-Agent': "#{USER_AGENT}/#{Smartsheet::VERSION}"
+            'User-Agent': user_agent
         }
         base[:Authorization] = "Bearer #{token}" if endpoint_spec.requires_auth?
 
         base
+      end
+
+      def user_agent
+        "#{USER_AGENT}/#{Smartsheet::VERSION}" +
+          (@app_user_agent.nil? ? '' : "/#{@app_user_agent}")
       end
 
       def assume_user

--- a/lib/smartsheet/api/request.rb
+++ b/lib/smartsheet/api/request.rb
@@ -8,10 +8,23 @@ module Smartsheet
     class Request
       attr_reader :method, :url, :headers, :params, :body
 
-      def initialize(token, endpoint_spec, request_spec, base_url, assume_user: nil)
+      def initialize(
+          token,
+          endpoint_spec,
+          request_spec,
+          base_url,
+          app_user_agent: nil,
+          assume_user: nil
+      )
         @method = endpoint_spec.method
         @url = Smartsheet::API::UrlBuilder.new(endpoint_spec, request_spec, base_url).build
-        @headers = Smartsheet::API::HeaderBuilder.new(token, endpoint_spec, request_spec, assume_user: assume_user).build
+        @headers = Smartsheet::API::HeaderBuilder.new(
+          token,
+          endpoint_spec,
+          request_spec,
+          app_user_agent: app_user_agent,
+          assume_user: assume_user
+        ).build
         @params = request_spec.params
         @body = Smartsheet::API::BodyBuilder.new(endpoint_spec, request_spec).build
       end

--- a/lib/smartsheet/api/request_client.rb
+++ b/lib/smartsheet/api/request_client.rb
@@ -1,3 +1,4 @@
+require 'smartsheet/version'
 require 'smartsheet/error'
 
 module Smartsheet
@@ -5,16 +6,31 @@ module Smartsheet
     # Composes {EndpointSpec endpoint specifications} and {RequestSpec request specifications} to
     # form a single {Request} that it submits to the provided client
     class RequestClient
-      def initialize(token, client, base_url, assume_user: nil, logger: MuteRequestLogger.new)
+      def initialize(
+          token,
+          client,
+          base_url,
+          app_user_agent: nil,
+          assume_user: nil,
+          logger: MuteRequestLogger.new
+      )
         @token = token
         @client = client
+        @app_user_agent = app_user_agent
         @assume_user = assume_user
         @logger = logger
         @base_url = base_url
       end
 
       def make_request(endpoint_spec, request_spec)
-        request = Request.new(token, endpoint_spec, request_spec, base_url, assume_user: assume_user)
+        request = Request.new(
+          token,
+          endpoint_spec,
+          request_spec,
+          base_url,
+          app_user_agent: app_user_agent,
+          assume_user: assume_user
+        )
 
         logger.log_request(request)
         client.make_request(request)
@@ -22,7 +38,7 @@ module Smartsheet
 
       private
 
-      attr_reader :token, :client, :assume_user, :logger, :base_url
+      attr_reader :token, :client, :app_user_agent, :assume_user, :logger, :base_url
     end
   end
 end

--- a/lib/smartsheet/client.rb
+++ b/lib/smartsheet/client.rb
@@ -73,6 +73,8 @@ module Smartsheet
     # @param logger [Logger] a logger to which request and response info will be recorded
     # @param log_full_body [Boolean] when true, request and response bodies will not be truncated in
     #   the logs
+    # @param user_agent [String] the name of the application, sent as part of the user agent for
+    #   requests; defaults as the name of the application
     # @param json_output [Boolean] when true, endpoints return raw JSON strings instead of hashes
     # @param assume_user [String] the email address of the user to impersonate; only available for
     #   admin roles
@@ -98,6 +100,7 @@ module Smartsheet
         token: nil,
         logger: nil,
         log_full_body: false,
+        user_agent: nil,
         json_output: false,
         assume_user: nil,
         max_retry_time: nil,
@@ -111,6 +114,8 @@ module Smartsheet
               API::MuteRequestLogger.new
 
       token = token_env_var if token.nil? || token.empty?
+
+      app_user_agent = user_agent.nil? ? File.basename($PROGRAM_NAME) : user_agent
 
       net_client = API::FaradayNetClient.new
 
@@ -132,6 +137,7 @@ module Smartsheet
           token,
           response_client,
           base_url,
+          app_user_agent: app_user_agent,
           assume_user: assume_user,
           logger: request_logger
       )

--- a/test/unit/smartsheet/api/header_builder_test.rb
+++ b/test/unit/smartsheet/api/header_builder_test.rb
@@ -36,9 +36,15 @@ describe Smartsheet::API::HeaderBuilder do
     @endpoint_spec = Smartsheet::API::EndpointSpec.new(:get, [], **spec)
   end
 
-  def when_headers_are_built(assume_user: nil)
-    @headers = Smartsheet::API::HeaderBuilder.new(TOKEN,@endpoint_spec,@request_spec, assume_user: assume_user)
-                  .build
+  def when_headers_are_built(assume_user: nil, app_user_agent: nil)
+    @headers = Smartsheet::API::HeaderBuilder.new(
+      TOKEN,
+      @endpoint_spec,
+      @request_spec,
+      assume_user: assume_user,
+      app_user_agent: app_user_agent
+    )
+    .build
   end
 
   it 'applies defaults' do
@@ -163,5 +169,25 @@ describe Smartsheet::API::HeaderBuilder do
 
     @headers.must_be_kind_of Hash
     (@headers.key? :'Assume-User').must_equal false
+  end
+
+  it 'appends app user agent correctly when set' do
+    given_endpoint_spec
+    given_request_spec
+
+    when_headers_are_built(app_user_agent: 'my-app')
+
+    @headers.must_be_kind_of Hash
+    @headers[:'User-Agent'].must_equal "smartsheet-ruby-sdk/#{Smartsheet::VERSION}/my-app"
+  end
+
+  it 'does not append app user agent when not set' do
+    given_endpoint_spec
+    given_request_spec
+
+    when_headers_are_built
+
+    @headers.must_be_kind_of Hash
+    @headers[:'User-Agent'].must_equal "smartsheet-ruby-sdk/#{Smartsheet::VERSION}"
   end
 end

--- a/test/unit/smartsheet/api/request_client_test.rb
+++ b/test/unit/smartsheet/api/request_client_test.rb
@@ -7,10 +7,19 @@ describe Smartsheet::API::RequestClient do
 
   before do
     @base_url = 'base'
+    @app_user_agent = 'user-agent'
+    @assume_user = 'john.doe'
 
     @endpoint_spec = Smartsheet::API::EndpointSpec.new(:get, ['x'])
     @request_spec = Smartsheet::API::RequestSpec.new(body: 'body')
-    @expected_request = Smartsheet::API::Request.new(TOKEN, @endpoint_spec, @request_spec, @base_url)
+    @expected_request = Smartsheet::API::Request.new(
+      TOKEN,
+      @endpoint_spec,
+      @request_spec,
+      @base_url,
+      app_user_agent: @app_user_agent,
+      assume_user: @assume_user
+    )
   end
 
   it 'delegates constructed requests to its client' do
@@ -26,7 +35,14 @@ describe Smartsheet::API::RequestClient do
         end
         .returns(return_value)
 
-    Smartsheet::API::RequestClient.new(TOKEN, client, @base_url).make_request(@endpoint_spec, @request_spec)
+    Smartsheet::API::RequestClient.new(
+      TOKEN,
+      client,
+      @base_url,
+      app_user_agent: @app_user_agent,
+      assume_user: @assume_user
+    )
+    .make_request(@endpoint_spec, @request_spec)
   end
 
   it 'returns the result of the client being called' do

--- a/test/unit/smartsheet/api/request_test.rb
+++ b/test/unit/smartsheet/api/request_test.rb
@@ -14,17 +14,28 @@ describe Smartsheet::API::Request do
     @base_url = 'base'
   end
 
-  def given_custom_request_builders
+  def given_mock_url_builder
     mock_url_builder = mock
     mock_url_builder.stubs(:build).returns(@some_url.clone)
     Smartsheet::API::UrlBuilder.stubs(:new).returns(mock_url_builder)
+  end
+
+  def given_mock_header_builder
     mock_header_builder = mock
     mock_header_builder.stubs(:build).returns(@some_header.clone)
     Smartsheet::API::HeaderBuilder.stubs(:new).returns(mock_header_builder)
+  end
+  
+  def given_mock_body_builder
     mock_body_builder = mock
     mock_body_builder.stubs(:build).returns(@some_body.clone)
     Smartsheet::API::BodyBuilder.stubs(:new).returns(mock_body_builder)
+  end
 
+  def given_custom_request_builders
+    given_mock_url_builder
+    given_mock_header_builder
+    given_mock_body_builder
   end
 
   it 'provides method' do
@@ -70,6 +81,46 @@ describe Smartsheet::API::Request do
     Smartsheet::API::Request
       .new(TOKEN, @endpoint_spec, request_spec, @base_url)
       .body.must_equal @some_body
+  end
+
+  it "includes the 'app user agent' header when provided" do
+    given_mock_url_builder
+    given_mock_body_builder
+
+    mock_app_user_agent = 'app-user-agent'
+    mock_header_builder = mock
+    mock_header_builder.stubs(:build).returns(@some_header.clone)
+    Smartsheet::API::HeaderBuilder
+      .expects(:new)
+      .with do |_token, _endpoind_spec, _request_spec, app_user_agent:, assume_user:|
+        app_user_agent == mock_app_user_agent
+      end
+      .returns(mock_header_builder)
+
+    request_spec = Smartsheet::API::RequestSpec.new
+    
+    Smartsheet::API::Request
+      .new(TOKEN, @endpoint_spec, request_spec, @base_url, app_user_agent: mock_app_user_agent)
+  end
+
+  it "includes the 'assume user' header when provided" do
+    given_mock_url_builder
+    given_mock_body_builder
+
+    mock_assume_user = 'assume-user'
+    mock_header_builder = mock
+    mock_header_builder.stubs(:build).returns(@some_header.clone)
+    Smartsheet::API::HeaderBuilder
+      .expects(:new)
+      .with do |_token, _endpoind_spec, _request_spec, app_user_agent:, assume_user:|
+        assume_user == mock_assume_user
+      end
+      .returns(mock_header_builder)
+
+    request_spec = Smartsheet::API::RequestSpec.new
+    
+    Smartsheet::API::Request
+      .new(TOKEN, @endpoint_spec, request_spec, @base_url, assume_user: mock_assume_user)
   end
 
   it 'should not be equal to other classes' do

--- a/test/unit/smartsheet/client_test.rb
+++ b/test/unit/smartsheet/client_test.rb
@@ -8,7 +8,15 @@ describe Smartsheet::Client do
   def given_request_client_expects_token
     Smartsheet::API::RequestClient
         .expects(:new)
-        .with {|token, _client| token == TOKEN}
+        .with { |token, _client| token == TOKEN}
+  end
+
+  def given_request_client_expects_app_user_agent(expected_app_user_agent)
+    Smartsheet::API::RequestClient
+        .expects(:new)
+        .with do |_token, _client, _base_url, app_user_agent:, assume_user:, logger:|
+          app_user_agent == expected_app_user_agent
+        end
   end
 
   it 'uses token from user' do
@@ -35,16 +43,45 @@ describe Smartsheet::Client do
     Smartsheet::Client.new
   end
 
+  it 'uses user agent when provided' do
+    user_agent = 'john-doe-app'
+
+    given_request_client_expects_app_user_agent(user_agent)
+
+    Smartsheet::Client.new(user_agent: user_agent)
+  end
+
+  describe 'default user agent' do
+    MOCK_PROGRAM_NAME = 'program-name'
+    ACTUAL_PROGRAM_NAME = $PROGRAM_NAME
+
+    before do
+      $PROGRAM_NAME = MOCK_PROGRAM_NAME
+    end
+
+    it 'uses program name as user agent when none provided' do
+      given_request_client_expects_app_user_agent(MOCK_PROGRAM_NAME)
+  
+      Smartsheet::Client.new
+    end
+
+    after do
+      $PROGRAM_NAME = ACTUAL_PROGRAM_NAME
+    end
+  end
+
   it 'initializes when all parameters are provided' do
       Smartsheet::Client.new(
           token: 'TOKEN',
+          user_agent: 'john-doe-app',
           assume_user: 'john.doe@smartsheet.com',
           json_output: true,
           max_retry_time: 10,
           backoff_method: ->{},
           logger: Logger.new(STDOUT),
           log_full_body: true,
-          base_url: 'smartsheet-dev-net')
+          base_url: 'smartsheet-dev-net'
+      )
   end
 end
 


### PR DESCRIPTION
Aside: one more of these configurations being piped down to all the client plumbing, and we'll probably want to do a little refactoring to wrap these configs up in a class of their own.  It might also clean up some of the white-box tests to make them a bit more useful and a bit less rigid.