### PR TITLE
Smartsheetgov

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+Updated documentation regarding the usage of baseUrl to clarify how clients can access smartsheetgov
 
 ## [1.2.0] - 2018-06-29
 ### Added

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ When creating the client object, pass an object with any of the following proper
 
 * `max_retry_time` - The maximum time in seconds to retry intermittent errors. (Defaults to 15 seconds.)
 
-* `base_url` - By default, the SDK connects to the production API URL. Provide a custom base URL to connect to other environments.
+* `base_url` - By default, the SDK connects to the production API URL. Provide a custom base URL to connect to other environments. For example, to access SmartsheetGov, the `base_url` will be `https://api.smartsheetgov.com/2.0`.
+
 
 ## Advanced Configuration Options
 ### Logging Configuration

--- a/lib/smartsheet/constants.rb
+++ b/lib/smartsheet/constants.rb
@@ -4,7 +4,6 @@ module Smartsheet
 
     USER_AGENT = 'smartsheet-ruby-sdk'.freeze
     API_URL = 'https://api.smartsheet.com/2.0'.freeze
-    GOV_API_URL = 'https://api.smartsheetgov.com/2.0'.freeze
 
     JSON_TYPE = 'application/json'.freeze
     EXCEL_TYPE = 'application/vnd.ms-excel'.freeze

--- a/lib/smartsheet/constants.rb
+++ b/lib/smartsheet/constants.rb
@@ -1,9 +1,10 @@
 module Smartsheet
   module Constants
-    VERSION = '1.2.1'.freeze
+    VERSION = '1.2.0'.freeze
 
     USER_AGENT = 'smartsheet-ruby-sdk'.freeze
     API_URL = 'https://api.smartsheet.com/2.0'.freeze
+    GOV_API_URL = 'https://api.smartsheetgov.com/2.0'.freeze
 
     JSON_TYPE = 'application/json'.freeze
     EXCEL_TYPE = 'application/vnd.ms-excel'.freeze

--- a/lib/smartsheet/constants.rb
+++ b/lib/smartsheet/constants.rb
@@ -1,6 +1,6 @@
 module Smartsheet
   module Constants
-    VERSION = '1.2.0'.freeze
+    VERSION = '1.2.1'.freeze
 
     USER_AGENT = 'smartsheet-ruby-sdk'.freeze
     API_URL = 'https://api.smartsheet.com/2.0'.freeze


### PR DESCRIPTION
In order to give clients more information on how to access smartsheetgov, I added some clearer documentation regarding the usage of the `base_url` parameter when creating a client.