### PR TITLE
2.101.0 update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,14 @@ dist: trusty
 sudo: false
 language: ruby
 rvm:
-  - 2.2
-  - 2.4
+  - 2.7
+  - 2.6
+  - 2.5
 before_install:
   - git clone https://github.com/smartsheet-platform/smartsheet-sdk-tests.git
   - smartsheet-sdk-tests/travis_scripts/install_wiremock.sh
   - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
-  - gem install bundler -v 1.15.4
+  - gem install bundler -v 1.17.3
 
 
 script:
@@ -24,5 +25,5 @@ deploy:
   on:
     repo: smartsheet-platform/smartsheet-ruby-sdk
     branch: master
-    rvm: 2.4
+    rvm: 2.7
 after_deploy: "echo 'Finished deployment process'"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.101.0] - 2020-09-28
+### Changed
+- Include modern Faraday 1.x as an allowed dependency
+
 ## [2.86.1] - 2019-11-18
 ### Added
 - Support for sheet summary endpoints

--- a/lib/smartsheet/constants.rb
+++ b/lib/smartsheet/constants.rb
@@ -1,6 +1,6 @@
 module Smartsheet
   module Constants
-    VERSION = '2.86.1'.freeze
+    VERSION = '2.101.0'.freeze
 
     USER_AGENT = 'smartsheet-ruby-sdk'.freeze
     API_URL = 'https://api.smartsheet.com/2.0'.freeze

--- a/smartsheet.gemspec
+++ b/smartsheet.gemspec
@@ -33,8 +33,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.2'
 
-  spec.add_dependency 'faraday', '~> 0.13.1'
-  spec.add_dependency 'faraday_middleware', '~> 0.10.0'
+  spec.add_dependency 'faraday', '>= 0.13.1', '< 2'
+  spec.add_dependency 'faraday_middleware', '>= 0.10.0', '< 2'
   spec.add_dependency 'plissken', '~> 1.2'
   spec.add_dependency 'awrence', '~> 1.0'
 

--- a/smartsheet.gemspec
+++ b/smartsheet.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'plissken', '~> 1.2'
   spec.add_dependency 'awrence', '~> 1.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.15'
+  spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'coveralls', '~> 0.8.21'
   spec.add_development_dependency 'cli', '~> 1.3'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/smartsheet.gemspec
+++ b/smartsheet.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'plissken', '~> 1.2'
   spec.add_dependency 'awrence', '~> 1.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.17'
+  spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'coveralls', '~> 0.8.21'
   spec.add_development_dependency 'cli', '~> 1.3'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
## [2.101.0] - 2020-09-28
### Changed
- Include modern Faraday 1.x as an allowed dependency