### PR TITLE
Support adding a state param to the authorization url

### DIFF
--- a/lib/smartsheet/endpoints/token/token.rb
+++ b/lib/smartsheet/endpoints/token/token.rb
@@ -13,9 +13,13 @@ module Smartsheet
       @client = client
     end
 
-    def build_authorization_url(client_id:, scopes:)
+    def build_authorization_url(client_id:, scopes:, state: nil)
       scopes_string = scopes.join('%20')
-      "https://app.smartsheet.com/b/authorize?response_type=code&client_id=#{client_id}&scope=#{scopes_string}"
+      url = "https://app.smartsheet.com/b/authorize?response_type=code&client_id=#{client_id}&scope=#{scopes_string}"
+      if state.present?
+        return "#{url}&state=#{state}"
+      end
+      return url
     end
 
     def get(client_id:, hash:, code:, params: {}, header_overrides: {})

--- a/test/unit/smartsheet/endpoints/token/token_test.rb
+++ b/test/unit/smartsheet/endpoints/token/token_test.rb
@@ -64,8 +64,19 @@ describe Smartsheet::Token do
         auth_url = client.token.build_authorization_url(
             client_id: 'client-id',
             scopes: ['READ_SHEETS', 'WRITE_SHEETS'])
-        
+
         auth_url.must_equal 'https://app.smartsheet.com/b/authorize?response_type=code&client_id=client-id&scope=READ_SHEETS%20WRITE_SHEETS'
+    end
+
+    it 'supports a `state` param' do
+        client = Smartsheet::Client.new(token: TOKEN)
+
+        auth_url = client.token.build_authorization_url(
+            client_id: 'client-id',
+            scopes: ['READ_SHEETS', 'WRITE_SHEETS'],
+            state: 'apples')
+
+        auth_url.must_equal 'https://app.smartsheet.com/b/authorize?response_type=code&client_id=client-id&scope=READ_SHEETS%20WRITE_SHEETS&state=apples'
     end
   end
 end


### PR DESCRIPTION
Adds support for a `state` param. This is needed for the 10,000ft OAuth client, and will be helpful for other clients, as well.

cc @timwellswa 